### PR TITLE
Handle undefined excludedFiles

### DIFF
--- a/tasks/blanket_mocha.js
+++ b/tasks/blanket_mocha.js
@@ -217,7 +217,7 @@ module.exports = function(grunt) {
 
         //Get the array of excludedFiles
         //Users should be able to define it in the command-line as an array or include it in the test file.
-        excludedFiles =  grunt.option('excludedFiles') || options.excludedFiles;
+        excludedFiles =  grunt.option('excludedFiles') || options.excludedFiles || [];
 
         if (grep) {
             options.mocha.grep = grep;


### PR DESCRIPTION
First of all thanks for the plugin! Integrating frontend Blanket.js in grunt is a godsend for automation.
## Excluded Files Bug

I'm not sure of an exact repro, but when I don't specify `options.excludedFiles` in a grunt file and get a coverage threshold failure, I get the grunt error:

```
Fatal error: Cannot call method 'indexOf' of undefined
```

This PR fixes that error with (I believe) the correct default behavior if no files are excluded.
## Other Things

_Separate Note_: I don't see an "issues" area to file specific tickets, so here are two other things that I noticed didn't work when trying to style check and test my change:

**Style Error**:

```
$ grunt jshint
Running "jshint:all" (jshint) task
Linting tasks/blanket_mocha.js...ERROR
[L393:C23] W004: 'failMsg' is already defined.
          var failMsg = stats.failures + '/' + stats.tests + ' tests failed (' +

Warning: Task "jshint:all" failed. Use --force to continue.

Aborted due to warnings.
```

**No Mocha test task**:

```
$ grunt test
Warning: Task "mocha" not found. Use --force to continue.

Aborted due to warnings.
```
