### PR TITLE
A few Reporter Fixes

### DIFF
--- a/support/mocha-blanket.js
+++ b/support/mocha-blanket.js
@@ -59,9 +59,9 @@
             });
 
             //I dont know why these became global leaks
-            runner.globals(['stats', 'failures', 'runner']);
+            runner.globals(['stats', 'failures', 'runner', '_$blanket']);
 
-            originalReporter(runner);
+            originalReporter.apply(this, [runner]);
         };
 
     // From mocha.js HTML reporter


### PR DESCRIPTION
I'm not sure if these are still necessary but this Pull Request:
- adds `_$blanket` to the ignored globals list
- calls `originalReporter` with the correct `this`
- adds `suiteURL` and `testURL` methods which are expected by HTMLReporter

These were added to get tests working on https://github.com/philschatz/css-coverage.js and https://github.com/philschatz/octokit.js
