### PR TITLE
port 'dest' option from grunt-mocha task

### DIFF
--- a/tasks/blanket_mocha.js
+++ b/tasks/blanket_mocha.js
@@ -18,6 +18,7 @@ module.exports = function(grunt) {
     var ok = true;
 
     var _ = grunt.util._;
+    var util = require('util');
 
     // Nodejs libs.
     var path = require('path');
@@ -268,6 +269,19 @@ module.exports = function(grunt) {
         // This task is asynchronous.
         var done = this.async();
 
+        // Hijack console.log to capture reporter output
+        var dest = this.data.dest;
+        var output = [];
+        var consoleLog = console.log;
+
+        // Only hijack if we really need to
+        if (dest) {
+            console.log = function() {
+                consoleLog.apply(console, arguments);
+                output.push(util.format.apply(util, arguments));
+            };
+        }
+
         // Process each filepath in-order.
         grunt.util.async.forEachSeries(urls, function(url, next) {
                     grunt.log.writeln('Testing: ' + url);
@@ -353,6 +367,12 @@ module.exports = function(grunt) {
                 },
                 // All tests have been run.
                 function() {
+
+                    if (dest) {
+                        // Restore console.log to original and write the output
+                        console.log = consoleLog;
+                        grunt.file.write(dest, output.join('\n'));
+                    }
 
                     grunt.log.writeln();
 


### PR DESCRIPTION
The grunt-mocha plugin allows you to output the results of the test runs to a file. This PR ports that functionality.
