### PR TITLE
Allow coverage to be run multiple times cleanly

### DIFF
--- a/tasks/blanket_mocha.js
+++ b/tasks/blanket_mocha.js
@@ -24,14 +24,7 @@ var helpers       = require('../support/mocha-helpers');
 
 module.exports = function(grunt) {
 
-    var ok = true;
-    var status, coverageThreshold, modulePattern, modulePatternRegex, excludedFiles, customThreshold, customModuleThreshold;
-    var totals = {
-        totalLines: 0,
-        coveredLines: 0,
-        moduleTotalStatements : {},
-        moduleTotalCoveredStatements : {}
-    };
+    var ok, totals, status, coverageThreshold, modulePattern, modulePatternRegex, excludedFiles, customThreshold, customModuleThreshold;
     // External lib.
     var phantomjs = require('grunt-lib-phantomjs').init(grunt);
 
@@ -219,6 +212,14 @@ module.exports = function(grunt) {
             // Log script errors as grunt errors
             logErrors: false
         });
+
+        ok = true;
+        totals = {
+            totalLines: 0,
+            coveredLines: 0,
+            moduleTotalStatements : {},
+            moduleTotalCoveredStatements : {}
+        };
 
         status = {blanketTotal: 0, blanketPass: 0, blanketFail: 0};
         coverageThreshold = grunt.option('threshold') || options.threshold;


### PR DESCRIPTION
Currently if this is run as a part of a watch task, the statement count will
carry over from the previous run which will throw off the coverage
percentage over time. The same applies to the ok status.

This will define both status and totals on a per run basis so each run is
clean, whether the task is run on watch or manually from the command line.
